### PR TITLE
preserve `libHacl_Hash_SHA2.a`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,7 @@ jobs:
               config.log config.cache Makefile pyconfig.h libpython*.a \
               Modules/Setup.local Modules/Setup.stdlib Modules/config.c \
               Modules/_decimal/libmpdec/libmpdec.a \
+              Modules/_hacl/*.a \
               Modules/expat/libexpat.a \
               Programs/python.o
             popd


### PR DESCRIPTION
I want to (statically) link against libpython. The build output has everything that I would need, except for this one module.