### PR TITLE
build: use python 3.14.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: "Create release"
 
 env:
   WASI_SDK_PATH: "/opt/wasi-sdk"
-  PYTHON_MAJOR_MINOR: "3.15"
+  PYTHON_MAJOR_MINOR: "3.14"
   TARGET_TRIPLE: "wasm32-wasip1"
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,10 @@ jobs:
       steps:
         - name: "Create draft release"
           run: |
-            gh release create v${{ env.PYTHON_MAJOR_MINOR }}.${{ inputs.python_micro }} --title "CPython ${{ env.PYTHON_MAJOR_MINOR }}.${{ inputs.python_micro}} w/ WASI SDK ${{ env.WASI_SDK_VERSION }}" --repo "brettcannon/cpython-wasi-build" --draft
+            gh release create v${{ env.PYTHON_MAJOR_MINOR }}.${{ inputs.python_micro }} \
+              --title "CPython ${{ env.PYTHON_MAJOR_MINOR }}.${{ inputs.python_micro}} \
+              w/ WASI SDK ${{ env.WASI_SDK_VERSION }}" \
+              --repo "influxdata/cpython-wasi-build" --draft
           env:
             GH_TOKEN: ${{ github.token }}
 
@@ -111,6 +114,6 @@ jobs:
             popd
         - name: "Attach files to the release"
           run: |
-            gh release upload v${{ env.PYTHON_MAJOR_MINOR }}.${{ inputs.python_micro }} zip-file/${{ env.EXECUTABLE_FILE_NAME }} cross-build/${{ env.TARGET_TRIPLE }}/${{ env.BUILD_ARTIFACTS_FILE_NAME }} --repo "brettcannon/cpython-wasi-build"
+            gh release upload v${{ env.PYTHON_MAJOR_MINOR }}.${{ inputs.python_micro }} zip-file/${{ env.EXECUTABLE_FILE_NAME }} cross-build/${{ env.TARGET_TRIPLE }}/${{ env.BUILD_ARTIFACTS_FILE_NAME }} --repo "influxdata/cpython-wasi-build"
           env:
             GH_TOKEN: ${{ github.token }}

--- a/README_influxdata.md
+++ b/README_influxdata.md
@@ -1,0 +1,5 @@
+This is a fork of https://github.com/brettcannon/cpython-wasi-build to address
+https://github.com/influxdata/datafusion-udf-wasm/issues/152.
+
+Official InfluxData builds that require `cpython-wasi-build` should use this
+repo so we have greater control of the supply chain.


### PR DESCRIPTION
I mistakenly created a release based on python 3.15. We use python 3.14 for https://github.com/influxdata/datafusion-udf-wasm, this fixes the version so we can create a release based on 3.14.