### PR TITLE
fix: run `apt-get update` before `install`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
           # https://devguide.python.org/getting-started/setup-building/#linux
           # Removed: gdb lcov libncurses5-dev libreadline6-dev tk-dev
           run: |
+            sudo apt-get update
             sudo apt-get install build-essential pkg-config \
             libbz2-dev libffi-dev libgdbm-dev libgdbm-compat-dev \
             liblzma-dev libsqlite3-dev libssl-dev \


### PR DESCRIPTION
Fixes failures because packages cannot be found (404).

I've seen this happen in one of my own builds and thought I should upstream the fix.